### PR TITLE
Basic foundation of language system

### DIFF
--- a/src/Facades/Languages.php
+++ b/src/Facades/Languages.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Carnival\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Languages extends Facade {
+    protected static function getFacadeAccessor() {
+        return 'languages';
+    }
+}

--- a/src/Language/Contracts/Language.php
+++ b/src/Language/Contracts/Language.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Carnival\Language\Contracts;
+
+interface Language {
+    function getName() : string;
+    function getVersion() : string;
+    function getLanguageFilePath() : string;
+}

--- a/src/Language/LanguageManager.php
+++ b/src/Language/LanguageManager.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Carnival\Language;
+
+use Carnival\Language\Contracts\Language;
+use Illuminate\Support\Collection;
+
+class LanguageManager {
+    private Collection $languages;
+
+    public function __construct() {
+        $this->languages = collect();
+    }
+
+    public function register(Language $language) : void {
+        $this->languages->put(get_class($language), $language);
+    }
+
+    public function get(string $languageClass) : ?Language {
+        return $this->languages->get($languageClass);
+    }
+
+    public function getAll() : Collection {
+        return $this->languages->values();
+    }
+}

--- a/src/Providers/LanguageServiceProvider.php
+++ b/src/Providers/LanguageServiceProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Carnival\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Carnival\Language\LanguageManager;
+
+class LanguageServiceProvider extends ServiceProvider {
+    public function register() {
+        $this->app->bind('languages', fn() => new LanguageManager);
+    }
+}

--- a/tst/Carnival/Facades/LanguagesTest.php
+++ b/tst/Carnival/Facades/LanguagesTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Carnival\Facades;
+
+use Carnival\Facades\Languages;
+use ReflectionClass;
+use Tests\Carnival\CarnivalTestCase;
+
+class LanguagesTest extends CarnivalTestCase {
+    public function testGetFacadeAccessor() {
+        $class = new ReflectionClass(Languages::class);
+        $method = $class->getMethod('getFacadeAccessor');
+        $method->setAccessible(true);
+        $this->assertEquals('languages', $method->invoke(null));
+    }
+}

--- a/tst/Carnival/Language/LanguageManagerTest.php
+++ b/tst/Carnival/Language/LanguageManagerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Carnival\Language;
+
+use Carnival\Language\Contracts\Language;
+use Carnival\Language\LanguageManager;
+use Mockery;
+use Tests\Carnival\CarnivalTestCase;
+
+class LanguageManagerTest extends CarnivalTestCase {
+    private LanguageManager $languageManager;
+    private Language $language;
+
+    protected function setUp() : void {
+        parent::setUp();
+
+        $this->languageManager = new LanguageManager;
+        $this->language = Mockery::mock(Language::class);
+    }
+
+    public function testRegister() {
+        $this->languageManager->register($this->language);
+        $this->assertEquals(collect([$this->language]), $this->languageManager->getAll());
+    }
+
+    public function testRegisterTwice() {
+        $this->languageManager->register($this->language);
+        $this->languageManager->register($this->language);
+        $this->assertEquals(collect([$this->language]), $this->languageManager->getAll());
+    }
+
+    public function testGet() {
+        $this->languageManager->register($this->language);
+        $this->assertEquals($this->language, $this->languageManager->get(get_class($this->language)));
+    }
+
+    public function testGetAllWithNoneRegistered() {
+        $this->assertEquals(collect(), $this->languageManager->getAll());
+    }
+}

--- a/tst/Carnival/Providers/LanguageServiceProviderTest.php
+++ b/tst/Carnival/Providers/LanguageServiceProviderTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Carnival\Providers;
+
+use Carnival\Language\LanguageManager;
+use Carnival\Providers\LanguageServiceProvider;
+use Illuminate\Contracts\Foundation\Application;
+use Mockery;
+use Tests\Carnival\CarnivalTestCase;
+
+class LanguageServiceProviderTest extends CarnivalTestCase {
+    public function testHookServiceProviderCanRegisterHookLibraryFacade() {
+        $application = Mockery::mock(Application::class);
+        $hookServiceProvider = new LanguageServiceProvider($application);
+        $application->shouldReceive('bind')->with(
+            'languages', 
+            Mockery::on(fn ($argument) => is_callable($argument) && $argument() instanceof LanguageManager)
+        )->once();
+        $hookServiceProvider->register();
+    }
+}


### PR DESCRIPTION
Creates the foundation of the language system.

Further down the line, the manager will likely also include setting functions such as getting a user's language, setting a user's language, setting the forum's default language, etc.

# Testing

`./vendor/bin/phpunit`