### PR TITLE
Add php dependency and set license to proprietary for Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "aidanscode/carnival",
     "description": "Core systems for AKFS",
     "type": "library",
-    "license": "UNLICENSED",
+    "license": "proprietary",
     "authors": [
         {
             "name": "Aidan",
@@ -14,6 +14,7 @@
         }
     ],
     "require": {
+        "php": ">= 8.1",
         "illuminate/collections": "^10.0",
         "illuminate/support": "^10.1",
         "illuminate/database": "^10.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "330e19fa39908aae55f3622d5c79e7f1",
+    "content-hash": "61892bd27afd37267d72eb3245cf84fa",
     "packages": [
         {
             "name": "brick/math",
@@ -2900,7 +2900,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">= 8.1"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Prepares the repo for Packagist

* Sets PHP dependency on v8.1 per Laravel's v10 upgrade doc
* Changes license from "UNLICENSED" to "proprietary" per Packagist complaining